### PR TITLE
Remove PR trigger, add manual workflow dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches: [main]
     tags: ['v*']
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The image no longer builds on pull requests. Use workflow_dispatch to manually trigger a build from any branch when testing is needed.